### PR TITLE
#75 add export as pdf option in order backoffice

### DIFF
--- a/packages/Webkul/Admin/src/Http/Controllers/Sales/OrderController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Sales/OrderController.php
@@ -12,6 +12,7 @@ use Webkul\Admin\Http\Resources\AddressResource;
 use Webkul\Admin\Http\Resources\CartResource;
 use Webkul\Checkout\Facades\Cart;
 use Webkul\Checkout\Repositories\CartRepository;
+use Webkul\Core\Traits\PDFHandler;
 use Webkul\Customer\Repositories\CustomerGroupRepository;
 use Webkul\Payment\Facades\Payment;
 use Webkul\Sales\Repositories\OrderCommentRepository;
@@ -20,6 +21,10 @@ use Webkul\Sales\Transformers\OrderResource;
 
 class OrderController extends Controller
 {
+
+    use PDFHandler;
+
+    
     /**
      * Create a new controller instance.
      *
@@ -259,5 +264,27 @@ class OrderController extends Controller
         if (! $cart->payment) {
             throw new \Exception(trans('admin::app.sales.orders.create.specify-payment-method'));
         }
+    }
+
+    /**
+     * Print and download the for the specified resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function printOrder()
+    {
+        // $order = $this->orderRepository->findOrFail($id);
+
+        return $this->downloadPDF(
+            view('admin::sales.orders.pdf')->render(),
+            // 'order-'.$order->created_at->format('d-m-Y')
+        );
+        
+        // $order = $this->orderRepository->findOrFail($id);
+
+        // return $this->downloadPDF(
+        //     view('admin::sales.orders.pdf', compact('orders'))->render(),
+        //     'order-'.$order->created_at->format('d-m-Y')
+        // );
     }
 }

--- a/packages/Webkul/Admin/src/Http/Controllers/Sales/OrderController.php
+++ b/packages/Webkul/Admin/src/Http/Controllers/Sales/OrderController.php
@@ -275,9 +275,11 @@ class OrderController extends Controller
     {
         // $order = $this->orderRepository->findOrFail($id);
 
+        // dd($this->orderRepository->all());
+        $orders = $this->orderRepository->all();
+
         return $this->downloadPDF(
-            view('admin::sales.orders.pdf')->render(),
-            // 'order-'.$order->created_at->format('d-m-Y')
+            view('admin::sales.orders.pdf', compact('orders'))->render()
         );
         
         // $order = $this->orderRepository->findOrFail($id);

--- a/packages/Webkul/Admin/src/Resources/lang/en/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en/app.php
@@ -4391,6 +4391,7 @@ return [
         'no-records' => 'Nothing to export',
         'xls'        => 'XLS',
         'xlsx'       => 'XLSX',
+        'pdf'        => 'PDF',
     ],
 
     'validations' => [

--- a/packages/Webkul/Admin/src/Resources/lang/en/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en/app.php
@@ -413,6 +413,10 @@ return [
                 'view'                           => 'View',
                 'write-your-comment'             => 'Write your comment',
             ],
+
+            'orders-pdf' => [
+                'orders'                          => 'Orders'
+            ],
         ],
 
         'shipments' => [
@@ -4390,8 +4394,7 @@ return [
         'export'     => 'Export',
         'no-records' => 'Nothing to export',
         'xls'        => 'XLS',
-        'xlsx'       => 'XLSX',
-        'pdf'        => 'PDF',
+        'xlsx'       => 'XLSX'
     ],
 
     'validations' => [

--- a/packages/Webkul/Admin/src/Resources/lang/en/app.php
+++ b/packages/Webkul/Admin/src/Resources/lang/en/app.php
@@ -415,7 +415,12 @@ return [
             ],
 
             'orders-pdf' => [
-                'orders'                          => 'Orders'
+                'orders'                          => 'Orders',
+                'order-id'                        => 'Order ID',
+                'status'                          => 'Status',
+                'channel'                         => 'Channel',
+                'customer-email'                  => 'Customer Email',
+                'total-items'                     => 'Total Items'
             ],
         ],
 

--- a/packages/Webkul/Admin/src/Resources/views/components/datagrid/export/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/datagrid/export/index.blade.php
@@ -11,13 +11,7 @@
         type="text/x-template"
         id="v-datagrid-export-template"
     >
-        <div>
-            <a
-                                href="{{ route('admin.sales.orders.print') }}"
-                                class="text-sm text-blue-600 transition-all hover:underline"
-                            >
-                                @lang('admin::app.sales.orders.view.download-pdf')
-                            </a>
+        <div class="flex">
             <x-admin::modal ref="exportModal">
                 <x-slot:toggle>
                     <button class="transparent-button hover:bg-gray-200 dark:text-white dark:hover:bg-gray-800">
@@ -52,10 +46,6 @@
                                 <option value="xlsx">
                                     @lang('admin::app.export.xlsx')
                                 </option>
-
-                                <option value="pdf">
-                                    @lang('admin::app.export.pdf')
-                                </option>
                             </x-admin::form.control-group.control>
                         </x-admin::form.control-group>
                     </x-admin::form>
@@ -71,6 +61,14 @@
                     </button>
                 </x-slot>
             </x-admin::modal>
+            <!-- add if -->
+            <button class="primary-button hover:bg-blue-200 dark:text-white dark:hover:bg-blue-800">
+                <a
+                                    href="{{ route('admin.sales.orders.print') }}"
+                                >
+                                    @lang('admin::app.sales.orders.view.download-pdf')
+                                </a>
+                                </button>
         </div>
     </script>
 

--- a/packages/Webkul/Admin/src/Resources/views/components/datagrid/export/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/datagrid/export/index.blade.php
@@ -12,6 +12,12 @@
         id="v-datagrid-export-template"
     >
         <div>
+            <a
+                                href="{{ route('admin.sales.orders.print') }}"
+                                class="text-sm text-blue-600 transition-all hover:underline"
+                            >
+                                @lang('admin::app.sales.orders.view.download-pdf')
+                            </a>
             <x-admin::modal ref="exportModal">
                 <x-slot:toggle>
                     <button class="transparent-button hover:bg-gray-200 dark:text-white dark:hover:bg-gray-800">
@@ -45,6 +51,10 @@
 
                                 <option value="xlsx">
                                     @lang('admin::app.export.xlsx')
+                                </option>
+
+                                <option value="pdf">
+                                    @lang('admin::app.export.pdf')
                                 </option>
                             </x-admin::form.control-group.control>
                         </x-admin::form.control-group>
@@ -100,7 +110,10 @@
                  * @param {object} data - Object containing available and applied properties.
                  * @returns {void}
                  */
-                updateProperties({ available, applied }) {
+                updateProperties({
+                    available,
+                    applied
+                }) {
                     this.available = available;
 
                     this.applied = applied;
@@ -112,8 +125,11 @@
                  * @returns {void}
                  */
                 download() {
-                    if (! this.available?.records?.length) {
-                        this.$emitter.emit('add-flash', { type: 'warning', message: '@lang('admin::app.export.no-records')' });
+                    if (!this.available?.records?.length) {
+                        this.$emitter.emit('add-flash', {
+                            type: 'warning',
+                            message: '@lang('admin::app.export.no-records')'
+                        });
 
                         this.$refs.exportModal.toggle();
                     } else {
@@ -151,7 +167,8 @@
                                  */
                                 const link = document.createElement('a');
                                 link.href = url;
-                                link.setAttribute('download', `${(Math.random() + 1).toString(36).substring(7)}.${this.format}`);
+                                link.setAttribute('download',
+                                    `${(Math.random() + 1).toString(36).substring(7)}.${this.format}`);
 
                                 /**
                                  * Adding a link to a document, clicking on the link, and then removing the link.

--- a/packages/Webkul/Admin/src/Resources/views/components/datagrid/export/index.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/components/datagrid/export/index.blade.php
@@ -61,14 +61,15 @@
                     </button>
                 </x-slot>
             </x-admin::modal>
-            <!-- add if -->
+
+            <!-- Download Orders PDF -->
+            @if(Route::current()->getName() == 'admin.sales.orders.index')
             <button class="primary-button hover:bg-blue-200 dark:text-white dark:hover:bg-blue-800">
-                <a
-                                    href="{{ route('admin.sales.orders.print') }}"
-                                >
-                                    @lang('admin::app.sales.orders.view.download-pdf')
-                                </a>
-                                </button>
+                <a href="{{ route('admin.sales.orders.print') }}">
+                    @lang('admin::app.sales.orders.view.download-pdf')
+                </a>
+            </button>
+            @endif
         </div>
     </script>
 

--- a/packages/Webkul/Admin/src/Resources/views/sales/invoices/pdf.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/sales/invoices/pdf.blade.php
@@ -248,6 +248,8 @@
                 <b>@lang('admin::app.sales.invoices.invoice-pdf.invoice')</b>
             </div>
 
+            @dd($invoice)
+
             <div class="page-content">
                 <!-- Invoice Information -->
                 <table class="{{ core()->getCurrentLocale()->direction }}">

--- a/packages/Webkul/Admin/src/Resources/views/sales/orders/pdf.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/sales/orders/pdf.blade.php
@@ -249,23 +249,23 @@
                     <thead>
                         <tr>
                             <th>
-                                Order ID
+                                @lang('admin::app.sales.orders.orders-pdf.order-id')
                             </th>
 
                             <th>
-                                Status
+                                @lang('admin::app.sales.orders.orders-pdf.status')
                             </th>
 
                             <th>
-                                Channel
+                                @lang('admin::app.sales.orders.orders-pdf.channel')
                             </th>
 
                             <th>
-                                Customer Email
+                                @lang('admin::app.sales.orders.orders-pdf.customer-email')
                             </th>
 
                             <th>
-                                Total Items
+                                @lang('admin::app.sales.orders.orders-pdf.total-items')
                             </th>
                         </tr>
                     </thead>

--- a/packages/Webkul/Admin/src/Resources/views/sales/orders/pdf.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/sales/orders/pdf.blade.php
@@ -239,7 +239,102 @@
     <div class="page">
         <!-- Header -->
         <div class="page-header">
-            <b>@lang('admin::app.sales.invoices.invoice-pdf.invoice')</b>
+            <b>@lang('admin::app.sales.orders.orders-pdf.orders')</b>
+        </div>
+
+        <div class="page-content">
+            <!-- Items -->
+            <div class="items">
+                <table class="{{ core()->getCurrentLocale()->direction }}">
+                    <thead>
+                        <tr>
+                            <th>
+                                Order ID
+                            </th>
+
+                            <th>
+                                Status
+                            </th>
+
+                            <th>
+                                Grand Total
+                            </th>
+
+                            <th>
+                                Pay Via
+                            </th>
+
+                            <th>
+                                Customer
+                            </th>
+                        </tr>
+                    </thead>
+
+                    {{-- <tbody>
+                        
+                        @foreach ($order->items as $item)
+                            <tr>
+                                <td>
+                                    {{ $item->getTypeInstance()->getOrderedItem($item)->sku }}
+                                </td>
+
+                                <td>
+                                    {{ $item->name }}
+
+                                    @if (isset($item->additional['attributes']))
+                                        <div>
+                                            @foreach ($item->additional['attributes'] as $attribute)
+                                                <b>{{ $attribute['attribute_name'] }} :
+                                                </b>{{ $attribute['option_label'] }}</br>
+                                            @endforeach
+                                        </div>
+                                    @endif
+                                </td>
+
+                                <td>
+                                    @if (core()->getConfigData('sales.taxes.sales.display_prices') == 'including_tax')
+                                        {!! core()->formatBasePrice($item->base_price_incl_tax, true) !!}
+                                    @elseif (core()->getConfigData('sales.taxes.sales.display_prices') == 'both')
+                                        {!! core()->formatBasePrice($item->base_price_incl_tax, true) !!}
+
+                                        <div class="small-text">
+                                            @lang('admin::app.sales.invoices.invoice-pdf.excl-tax')
+
+                                            <span>
+                                                {{ core()->formatPrice($item->base_price) }}
+                                            </span>
+                                        </div>
+                                    @else
+                                        {!! core()->formatBasePrice($item->base_price, true) !!}
+                                    @endif
+                                </td>
+
+                                <td>
+                                    {{ $item->qty }}
+                                </td>
+
+                                <td>
+                                    @if (core()->getConfigData('sales.taxes.sales.display_subtotal') == 'including_tax')
+                                        {!! core()->formatBasePrice($item->base_total_incl_tax, true) !!}
+                                    @elseif (core()->getConfigData('sales.taxes.sales.display_subtotal') == 'both')
+                                        {!! core()->formatBasePrice($item->base_total_incl_tax, true) !!}
+
+                                        <div class="small-text">
+                                            @lang('admin::app.sales.invoices.invoice-pdf.excl-tax')
+
+                                            <span>
+                                                {{ core()->formatPrice($item->base_total) }}
+                                            </span>
+                                        </div>
+                                    @else
+                                        {!! core()->formatBasePrice($item->base_total, true) !!}
+                                    @endif
+                                </td>
+                            </tr>
+                        @endforeach
+                    </tbody> --}}
+                </table>
+            </div>
         </div>
     </div>
 </body>

--- a/packages/Webkul/Admin/src/Resources/views/sales/orders/pdf.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/sales/orders/pdf.blade.php
@@ -257,82 +257,40 @@
                             </th>
 
                             <th>
-                                Grand Total
+                                Channel
                             </th>
 
                             <th>
-                                Pay Via
+                                Customer Email
                             </th>
 
                             <th>
-                                Customer
+                                Total Items
                             </th>
                         </tr>
                     </thead>
 
-                    {{-- <tbody>
-                        
-                        @foreach ($order->items as $item)
+                    <tbody>
+                        @foreach ($orders as $order)
                             <tr>
                                 <td>
-                                    {{ $item->getTypeInstance()->getOrderedItem($item)->sku }}
+                                    {{ $order->id }}
                                 </td>
-
                                 <td>
-                                    {{ $item->name }}
-
-                                    @if (isset($item->additional['attributes']))
-                                        <div>
-                                            @foreach ($item->additional['attributes'] as $attribute)
-                                                <b>{{ $attribute['attribute_name'] }} :
-                                                </b>{{ $attribute['option_label'] }}</br>
-                                            @endforeach
-                                        </div>
-                                    @endif
+                                    {{ $order->status }}
                                 </td>
-
                                 <td>
-                                    @if (core()->getConfigData('sales.taxes.sales.display_prices') == 'including_tax')
-                                        {!! core()->formatBasePrice($item->base_price_incl_tax, true) !!}
-                                    @elseif (core()->getConfigData('sales.taxes.sales.display_prices') == 'both')
-                                        {!! core()->formatBasePrice($item->base_price_incl_tax, true) !!}
-
-                                        <div class="small-text">
-                                            @lang('admin::app.sales.invoices.invoice-pdf.excl-tax')
-
-                                            <span>
-                                                {{ core()->formatPrice($item->base_price) }}
-                                            </span>
-                                        </div>
-                                    @else
-                                        {!! core()->formatBasePrice($item->base_price, true) !!}
-                                    @endif
+                                    {{ $order->channel_name }}
                                 </td>
-
                                 <td>
-                                    {{ $item->qty }}
+                                    {{ $order->customer_email }}
                                 </td>
-
                                 <td>
-                                    @if (core()->getConfigData('sales.taxes.sales.display_subtotal') == 'including_tax')
-                                        {!! core()->formatBasePrice($item->base_total_incl_tax, true) !!}
-                                    @elseif (core()->getConfigData('sales.taxes.sales.display_subtotal') == 'both')
-                                        {!! core()->formatBasePrice($item->base_total_incl_tax, true) !!}
-
-                                        <div class="small-text">
-                                            @lang('admin::app.sales.invoices.invoice-pdf.excl-tax')
-
-                                            <span>
-                                                {{ core()->formatPrice($item->base_total) }}
-                                            </span>
-                                        </div>
-                                    @else
-                                        {!! core()->formatBasePrice($item->base_total, true) !!}
-                                    @endif
+                                    {{ $order->total_item_count }}
                                 </td>
                             </tr>
                         @endforeach
-                    </tbody> --}}
+                    </tbody> 
                 </table>
             </div>
         </div>

--- a/packages/Webkul/Admin/src/Resources/views/sales/orders/pdf.blade.php
+++ b/packages/Webkul/Admin/src/Resources/views/sales/orders/pdf.blade.php
@@ -1,0 +1,247 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html lang="{{ app()->getLocale() }}" dir="{{ core()->getCurrentLocale()->direction }}">
+
+<head>
+    <!-- meta tags -->
+    <meta http-equiv="Cache-control" content="no-cache">
+
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+
+    @php
+        $fontPath = [];
+
+        // Get the default locale code.
+        $getLocale = app()->getLocale();
+
+        // Get the current currency code.
+        $currencyCode = core()->getBaseCurrencyCode();
+
+        if ($getLocale == 'en' && $currencyCode == 'INR') {
+            $fontFamily = [
+                'regular' => 'DejaVu Sans',
+                'bold' => 'DejaVu Sans',
+            ];
+        } else {
+            $fontFamily = [
+                'regular' => 'Arial, sans-serif',
+                'bold' => 'Arial, sans-serif',
+            ];
+        }
+
+        if (in_array($getLocale, ['ar', 'he', 'fa', 'tr', 'ru', 'uk'])) {
+            $fontFamily = [
+                'regular' => 'DejaVu Sans',
+                'bold' => 'DejaVu Sans',
+            ];
+        } elseif ($getLocale == 'zh_CN') {
+            $fontPath = [
+                'regular' => asset('fonts/NotoSansSC-Regular.ttf'),
+                'bold' => asset('fonts/NotoSansSC-Bold.ttf'),
+            ];
+
+            $fontFamily = [
+                'regular' => 'Noto Sans SC',
+                'bold' => 'Noto Sans SC Bold',
+            ];
+        } elseif ($getLocale == 'ja') {
+            $fontPath = [
+                'regular' => asset('fonts/NotoSansJP-Regular.ttf'),
+                'bold' => asset('fonts/NotoSansJP-Bold.ttf'),
+            ];
+
+            $fontFamily = [
+                'regular' => 'Noto Sans JP',
+                'bold' => 'Noto Sans JP Bold',
+            ];
+        } elseif ($getLocale == 'hi_IN') {
+            $fontPath = [
+                'regular' => asset('fonts/Hind-Regular.ttf'),
+                'bold' => asset('fonts/Hind-Bold.ttf'),
+            ];
+
+            $fontFamily = [
+                'regular' => 'Hind',
+                'bold' => 'Hind Bold',
+            ];
+        } elseif ($getLocale == 'bn') {
+            $fontPath = [
+                'regular' => asset('fonts/NotoSansBengali-Regular.ttf'),
+                'bold' => asset('fonts/NotoSansBengali-Bold.ttf'),
+            ];
+
+            $fontFamily = [
+                'regular' => 'Noto Sans Bengali',
+                'bold' => 'Noto Sans Bengali Bold',
+            ];
+        } elseif ($getLocale == 'sin') {
+            $fontPath = [
+                'regular' => asset('fonts/NotoSansSinhala-Regular.ttf'),
+                'bold' => asset('fonts/NotoSansSinhala-Bold.ttf'),
+            ];
+
+            $fontFamily = [
+                'regular' => 'Noto Sans Sinhala',
+                'bold' => 'Noto Sans Sinhala Bold',
+            ];
+        }
+    @endphp
+
+    <!-- lang supports inclusion -->
+    <style type="text/css">
+        @if (!empty($fontPath['regular']))
+            @font-face {
+                src: url({{ $fontPath['regular'] }}) format('truetype');
+                font-family: {{ $fontFamily['regular'] }};
+            }
+        @endif
+
+        @if (!empty($fontPath['bold']))
+            @font-face {
+                src: url({{ $fontPath['bold'] }}) format('truetype');
+                font-family: {{ $fontFamily['bold'] }};
+                font-style: bold;
+            }
+        @endif
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+            font-family: {{ $fontFamily['regular'] }};
+        }
+
+        body {
+            font-size: 10px;
+            color: #091341;
+            font-family: "{{ $fontFamily['regular'] }}";
+        }
+
+        b,
+        th {
+            font-family: "{{ $fontFamily['bold'] }}";
+        }
+
+        .page-content {
+            padding: 12px;
+        }
+
+        .page-header {
+            border-bottom: 1px solid #E9EFFC;
+            text-align: center;
+            font-size: 24px;
+            text-transform: uppercase;
+            color: #000DBB;
+            padding: 24px 0;
+            margin: 0;
+        }
+
+        .logo-container {
+            position: absolute;
+            top: 20px;
+            left: 20px;
+        }
+
+        .logo-container.rtl {
+            left: auto;
+            right: 20px;
+        }
+
+        .logo-container img {
+            max-width: 100%;
+            height: auto;
+        }
+
+        .page-header b {
+            display: inline-block;
+            vertical-align: middle;
+        }
+
+        .small-text {
+            font-size: 7px;
+        }
+
+        table {
+            width: 100%;
+            border-spacing: 1px 0;
+            border-collapse: separate;
+            margin-bottom: 16px;
+        }
+
+        table thead th {
+            background-color: #E9EFFC;
+            color: #000DBB;
+            padding: 6px 18px;
+            text-align: left;
+        }
+
+        table.rtl thead tr th {
+            text-align: right;
+        }
+
+        table tbody td {
+            padding: 9px 18px;
+            border-bottom: 1px solid #E9EFFC;
+            text-align: left;
+            vertical-align: top;
+        }
+
+        table.rtl tbody tr td {
+            text-align: right;
+        }
+
+        .summary {
+            width: 100%;
+            display: inline-block;
+        }
+
+        .summary table {
+            float: right;
+            width: 250px;
+            padding-top: 5px;
+            padding-bottom: 5px;
+            background-color: #E9EFFC;
+            white-space: nowrap;
+        }
+
+        .summary table.rtl {
+            width: 280px;
+        }
+
+        .summary table.rtl {
+            margin-right: 480px;
+        }
+
+        .summary table td {
+            padding: 5px 10px;
+        }
+
+        .summary table td:nth-child(2) {
+            text-align: center;
+        }
+
+        .summary table td:nth-child(3) {
+            text-align: right;
+        }
+    </style>
+</head>
+
+<body dir="{{ core()->getCurrentLocale()->direction }}">
+    <div class="logo-container {{ core()->getCurrentLocale()->direction }}">
+        @if (core()->getConfigData('sales.invoice_settings.pdf_print_outs.logo'))
+            <img
+                src="data:image/png;base64,{{ base64_encode(file_get_contents(Storage::url(core()->getConfigData('sales.invoice_settings.pdf_print_outs.logo')))) }}" />
+        @else
+            <img
+                src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIIAAAAkCAYAAABFRuIOAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAV6SURBVHgB7VrRceM2EH3K+eMyk5nIacBwBfFVELoC+yoIXYHtCs6u4HwVmFdBfH/5E5MGrFRguAIrf/nJKHwiEC5XIAVKViLq+GbWFIAFCGCXi92FgQEDNkBS0MeCHgt6KWjunpOCrgoyGLD3oALMI+gDBvQGb9ANvxSUivK0oF8L+lLQrKC3BY1dW+Kev2HAXoFfuP/aeSQkDXxpQU+C9xwD9gYGlWAp5HEEv/QdVvEP6AnuUClCEtnnSvS5woC9AKMBbw26wFuFCQbsBbxAH9ANGarjYcAO45tIPn/GT9ENVvX/mkDnmhaU1vAEO45RsPZ0Pq+VJ47N3ADHHdIDT7eFKtz4MaHGHLX05MZ9FOXPKK1LX5AWdC/KDK0PscM4wG6CFiQR5b7lIrQF2HmLuKuK0HdkBZ2hSrXfYnPQQkoFO8UrYlCE7YC+1DuUgpuhu28VAsdKsCX0URHGjiy6Yd1+su/MUQzIl0fyGve02A7MqvHjoobvnEX69gid4PnfGrwCUlS3nT6FPUH97kOCgvvgeF5UP45DZ86gHbL/k3s+uncmrs6TTKUb1XaH8HpkfkbPLRFzCM31XpAJjJ+oubfuWVzUQPxl1xMo+x2MS5JojxoS1JNQFu1C40ZfizJ5uaGrnDSL8qy1qt6gvGBrC/uYU5HCv0AV2RjUk2+Za4ebE8dOsHpuxyj3YRUv15B3HD9DuWcLCxebR1j/q2a/g42dZrOinSlsGW5aLJ/LrJsFxr3HMmJi/3Uv0y5RF5I/Qkhyzus6mDGKQ6QoFWaBeEX4/8FNoubTkjAm1xtFZUhEme2560P+Y/ekE2cFX6L6pagrHgV17fqO3DhdM6wSUoGsG+/U0TtX5twzx3Pt2rRinwqairmfqPH9npEusLx29umNIljUzR+Fc1PQJ8UnNzkXfaQl4KZpJZKb97NqoyDuxBi2oPeIdwQ1xuq3Ue0W5do8plheA1BZEdl2qXjknhEZqiPKY7HevkQN/h9fNCgguXij2rnR567+SNWjoWzEb74zQxjMdiboDq7lUrz3EVWISWLyLEd8dAIxllToHOEowdcbV074py+KMG2ot6r8vfjNzb7BZlm9rsKIAZVXJpsIn0kl8YizKOf+GfHQ6/yzhdeq9x/1RRGaHDfTUJ+iHrJRoA+qX9LQ16Ia17h3hxTxJ6wHi9IPSFEphF4f67KCnhF/BGmlbYv1tdI898VHOGuo1+f5Hw38dMIuBLV55Ppeg561UXW0Nik2Q4bS1+DcRu6pfZ5VkYsEFcGqvibAZ1Afd6HkfVEEg2WBeNMv4b96qfF6g4i2r1k6hv7d/jp5guYEUSwMypBVC5kCyVSdXMezaksCfPoo0WFwguV/ElooX59SzOeOLKqUr0SGyozSMiTut0+wfHHlM7TnAKgE9LYn6h0JXgfMFKaOrCDvJ0jI44yKIi0g55ejFDQt3B0q/8ML36ByRoHlPftX+fpiEeQZbbC8oBz1zCI3xIoyBe/TsedYndPn+2iqHxraH9T7YsF5p6JsUMXy56iv6xb1dWdYnnfi+vijkAJ/H+ALfThTx7tAXxSBm86Nsareokq4zFQ960Jed464K1yLcqOO3fPCPQ/dcxzgX4WZG4/zmjbw5G5+N4G+TWuCmI9177hoeEeOcs9qibVRcMjQXcNro/2uoQ0G1U2gjeD3SZsZut0e0gf5hOY5TFD3WQ6BtWJ/T13m12VNUbx9VIT/AinKY8SiPAZkQusE5TlvBH+G5YxdrzAoQhiMDEwkr0X4BrNXCEcNv/+Arxg0pTIN3AaLPVACIvxVvjncvkX4+2WXLQJhUHrlPAp+RP0spxNGpy3HnmBQhAEL9On/EQZsEWEfYTSPibMH7BH+AYPFe45OKcPoAAAAAElFTkSuQmCC" />
+        @endif
+    </div>
+
+    <div class="page">
+        <!-- Header -->
+        <div class="page-header">
+            <b>@lang('admin::app.sales.invoices.invoice-pdf.invoice')</b>
+        </div>
+    </div>
+</body>
+
+</html>

--- a/packages/Webkul/Admin/src/Routes/sales-routes.php
+++ b/packages/Webkul/Admin/src/Routes/sales-routes.php
@@ -47,6 +47,8 @@ Route::group(['middleware' => ['admin'], 'prefix' => config('app.admin_url')], f
             Route::post('comment/{order_id}', 'comment')->name('admin.sales.orders.comment');
 
             Route::get('search', 'search')->name('admin.sales.orders.search');
+
+            Route::get('print', 'printOrder')->name('admin.sales.orders.print');
         });
 
         /**


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->
#75 

## Description
<!--- Please describe your changes in detail. -->
Added a button to be able to download a PDF with all the orders in the backoffice.

## How To Test This?
<!--- Please describe in detail how to test the changes made in this pull request. -->
Check the Orders section from the Sales section and find the Download PDF button.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->

## Branch Selection
<!--- Please specify the target branch for this pull request. -->
- [ ] Target Branch: master 

## Pint
<!---  Please make sure all the pint tests are passed. -->

## Tailwind Reordering
<!--- Please make sure all the Tailwind classes are reordered. -->

## Evidence
![image](https://github.com/user-attachments/assets/4ffe2dd9-947f-4fb5-b50b-eaa04f76d2d1)
![image](https://github.com/user-attachments/assets/e06ebdb0-8f3f-457c-a513-d8aefeed0bb7)

